### PR TITLE
Display Help even on dark background

### DIFF
--- a/client/public/style.css
+++ b/client/public/style.css
@@ -186,4 +186,3 @@ h1 {
     left: 10px;
 }
 
-.dark h1, .dark #help { display: none; }


### PR DESCRIPTION
As requested by a user [in the forum](https://forum.cozy.io/t/application-term-aide-non-visible-sur-font-noir/850/1).
